### PR TITLE
Add Font Scaling and Display Zoom Disabling Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The `MobileAccessibility` object, exposed by `window.MobileAccessibility`, provi
 - MobileAccessibility.postNotification
 - MobileAccessibility.speak
 - MobileAccessibility.stop
-- MobileAccessibility.disableDisplaySize
+- MobileAccessibility.disableDisplayZoom
 
 --------------------------------------------------------
 #### MobileAccessibility.isScreenReaderRunning(callback)
@@ -714,14 +714,14 @@ Stops speech.
 - iOS
 
 --------------------------------------------------------
-#### MobileAccessibility.disableDisplaySize()
+#### MobileAccessibility.disableDisplayZoom()
 
 Disables display size setting preference.
 
 ##### Usage
 
 ```javascript
-    MobileAccessibility.disableDisplaySize();
+    MobileAccessibility.disableDisplayZoom();
 ```
 ##### Supported Platforms
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The `MobileAccessibility` object, exposed by `window.MobileAccessibility`, provi
 - MobileAccessibility.postNotification
 - MobileAccessibility.speak
 - MobileAccessibility.stop
+- MobileAccessibility.disableDisplaySize
 
 --------------------------------------------------------
 #### MobileAccessibility.isScreenReaderRunning(callback)
@@ -711,6 +712,20 @@ Stops speech.
 - Amazon Fire OS
 - Android
 - iOS
+
+--------------------------------------------------------
+#### MobileAccessibility.disableDisplaySize()
+
+Disables display size setting preference.
+
+##### Usage
+
+```javascript
+    MobileAccessibility.disableDisplaySize();
+```
+##### Supported Platforms
+
+- Android
 
 ----------
 ### Events

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "phonegap-plugin-mobile-accessibility",
   "description": "PhoneGap Mobile Accessibility Plugin",
   "version": "1.0.5",
-  "homepage": "http://github.com/phonegap/phonegap-mobile-accessibility#readme",
+  "homepage": "https://github.com/newage99/phonegap-plugin-mobile-accessibility",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/phonegap/phonegap-mobile-accessibility.git"
   },
   "bugs": {
-    "url": "https://github.com/phonegap/phonegap-mobile-accessibility/issues"
+    "url": "https://github.com/newage99/phonegap-plugin-mobile-accessibility/issues"
   },
   "cordova": {
     "id": "phonegap-plugin-mobile-accessibility",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="phonegap-plugin-mobile-accessibility"
-    version="1.0.8">
+    version="1.0.9">
     <name>Mobile Accessibility</name>
     <description>PhoneGap Mobile Accessibility Plugin</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="phonegap-plugin-mobile-accessibility"
-    version="1.0.5-dev">
+    version="1.0.7">
     <name>Mobile Accessibility</name>
     <description>PhoneGap Mobile Accessibility Plugin</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -59,6 +59,7 @@
         <source-file src="src/android/com/phonegap/plugin/mobileaccessibility/IceCreamSandwichMobileAccessibilityHelper.java" target-dir="src/com/phonegap/plugin/mobileaccessibility" />
         <source-file src="src/android/com/phonegap/plugin/mobileaccessibility/JellyBeanMobileAccessibilityHelper.java" target-dir="src/com/phonegap/plugin/mobileaccessibility" />
         <source-file src="src/android/com/phonegap/plugin/mobileaccessibility/KitKatMobileAccessibilityHelper.java" target-dir="src/com/phonegap/plugin/mobileaccessibility" />
+        <source-file src="src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java" target-dir="src/com/phonegap/plugin/mobileaccessibility" />
         <asset src="www/android" target="plugins/com.phonegap.plugin.mobile-accessibility/android" />
     </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="phonegap-plugin-mobile-accessibility"
-    version="1.0.7">
+    version="1.0.8">
     <name>Mobile Accessibility</name>
     <description>PhoneGap Mobile Accessibility Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/com/phonegap/plugin/mobileaccessibility/AbstractMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/AbstractMobileAccessibilityHelper.java
@@ -38,5 +38,5 @@ abstract class AbstractMobileAccessibilityHelper {
     public abstract void announceForAccessibility(CharSequence text);
     public abstract double getTextZoom();
     public abstract void setTextZoom(double textZoom);
-    public abstract void disableDisplayZoom();
+    public abstract void setFontScaleToOne();
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/AbstractMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/AbstractMobileAccessibilityHelper.java
@@ -38,4 +38,5 @@ abstract class AbstractMobileAccessibilityHelper {
     public abstract void announceForAccessibility(CharSequence text);
     public abstract double getTextZoom();
     public abstract void setTextZoom(double textZoom);
+    public abstract void disableDisplayZoom();
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -190,11 +190,8 @@ public class DonutMobileAccessibilityHelper extends
 
     @Override
     public void setFontScaleToOne() {
-        //String fontScale = "";
         Configuration config = mMobileAccessibility.cordova.getActivity().getResources().getConfiguration();
         config.fontScale = 1;
         mMobileAccessibility.cordova.getActivity().getResources().updateConfiguration(config, mMobileAccessibility.cordova.getActivity().getResources().getDisplayMetrics());
-        //fontScale = String.valueOf(mMobileAccessibility.cordova.getActivity().getResources().getConfiguration().fontScale);
-        //Toast.makeText(mMobileAccessibility.cordova.getActivity().getBaseContext(), fontScale, Toast.LENGTH_SHORT).show();
     }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -187,7 +187,16 @@ public class DonutMobileAccessibilityHelper extends
     }
 
     @Override
-    public void disableDisplayZoom() {
-        //Toast.makeText(mMobileAccessibility.cordova.getActivity().getBaseContext(), "Default Donut disableDisplayZoom", Toast.LENGTH_SHORT).show();
+    public void setFontScaleToOne() {
+        String fontScale = "";
+        try {
+            Configuration config = mMobileAccessibility.cordova.getActivity().getResources().getConfiguration();
+            config.fontScale = 1;
+            mMobileAccessibility.cordova.getActivity().getResources().updateConfiguration(config, mMobileAccessibility.cordova.getActivity().getResources().getDisplayMetrics());
+            fontScale = String.valueOf(mMobileAccessibility.cordova.getActivity().getResources().getConfiguration().fontScale);
+        } catch (Exception e) {
+            fontScale = e.toString();
+        }
+        Toast.makeText(mMobileAccessibility.cordova.getActivity().getBaseContext(), fontScale, Toast.LENGTH_SHORT).show();
     }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -187,5 +187,6 @@ public class DonutMobileAccessibilityHelper extends
 
     @Override
     public void disableDisplayZoom() {
+        android.widget.Toast.makeText(mMobileAccessibility.cordova.getActivity().getBaseContext(), "Default Donut disableDisplayZoom", Toast.LENGTH_SHORT).show();
     }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -193,6 +193,5 @@ public class DonutMobileAccessibilityHelper extends
         Configuration config = mMobileAccessibility.cordova.getActivity().getResources().getConfiguration();
         config.fontScale = 1;
         mMobileAccessibility.cordova.getActivity().getResources().updateConfiguration(config, mMobileAccessibility.cordova.getActivity().getResources().getDisplayMetrics());
-        // 1.0.7
     }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -190,15 +190,11 @@ public class DonutMobileAccessibilityHelper extends
 
     @Override
     public void setFontScaleToOne() {
-        String fontScale = "";
-        try {
-            Configuration config = mMobileAccessibility.cordova.getActivity().getResources().getConfiguration();
-            config.fontScale = 1;
-            mMobileAccessibility.cordova.getActivity().getResources().updateConfiguration(config, mMobileAccessibility.cordova.getActivity().getResources().getDisplayMetrics());
-            fontScale = String.valueOf(mMobileAccessibility.cordova.getActivity().getResources().getConfiguration().fontScale);
-        } catch (Exception e) {
-            fontScale = e.toString();
-        }
-        Toast.makeText(mMobileAccessibility.cordova.getActivity().getBaseContext(), fontScale, Toast.LENGTH_SHORT).show();
+        //String fontScale = "";
+        Configuration config = mMobileAccessibility.cordova.getActivity().getResources().getConfiguration();
+        config.fontScale = 1;
+        mMobileAccessibility.cordova.getActivity().getResources().updateConfiguration(config, mMobileAccessibility.cordova.getActivity().getResources().getDisplayMetrics());
+        //fontScale = String.valueOf(mMobileAccessibility.cordova.getActivity().getResources().getConfiguration().fontScale);
+        //Toast.makeText(mMobileAccessibility.cordova.getActivity().getBaseContext(), fontScale, Toast.LENGTH_SHORT).show();
     }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -184,4 +184,8 @@ public class DonutMobileAccessibilityHelper extends
             e.printStackTrace();
         }
     }
+
+    @Override
+    public void disableDisplaySize() {
+    }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -186,6 +186,6 @@ public class DonutMobileAccessibilityHelper extends
     }
 
     @Override
-    public void disableDisplaySize() {
+    public void disableDisplayZoom() {
     }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -188,6 +188,6 @@ public class DonutMobileAccessibilityHelper extends
 
     @Override
     public void disableDisplayZoom() {
-        Toast.makeText(mMobileAccessibility.cordova.getActivity().getBaseContext(), "Default Donut disableDisplayZoom", Toast.LENGTH_SHORT).show();
+        //Toast.makeText(mMobileAccessibility.cordova.getActivity().getBaseContext(), "Default Donut disableDisplayZoom", Toast.LENGTH_SHORT).show();
     }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -30,10 +30,12 @@ import android.view.View;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.widget.Toast;
+import android.content.res.Configuration;
 
 import java.lang.IllegalAccessException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
 
 @TargetApi(Build.VERSION_CODES.DONUT)
 public class DonutMobileAccessibilityHelper extends

--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -193,5 +193,6 @@ public class DonutMobileAccessibilityHelper extends
         Configuration config = mMobileAccessibility.cordova.getActivity().getResources().getConfiguration();
         config.fontScale = 1;
         mMobileAccessibility.cordova.getActivity().getResources().updateConfiguration(config, mMobileAccessibility.cordova.getActivity().getResources().getDisplayMetrics());
+        // 1.0.7
     }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -29,6 +29,7 @@ import android.view.accessibility.AccessibilityManager;
 import android.view.View;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.widget.Toast;
 
 import java.lang.IllegalAccessException;
 import java.lang.reflect.InvocationTargetException;
@@ -187,6 +188,6 @@ public class DonutMobileAccessibilityHelper extends
 
     @Override
     public void disableDisplayZoom() {
-        android.widget.Toast.makeText(mMobileAccessibility.cordova.getActivity().getBaseContext(), "Default Donut disableDisplayZoom", Toast.LENGTH_SHORT).show();
+        Toast.makeText(mMobileAccessibility.cordova.getActivity().getBaseContext(), "Default Donut disableDisplayZoom", Toast.LENGTH_SHORT).show();
     }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
@@ -52,7 +52,9 @@ public class MobileAccessibility extends CordovaPlugin {
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mMobileAccessibilityHelper = new OreoMobileAccessibilityHelper();
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             mMobileAccessibilityHelper = new KitKatMobileAccessibilityHelper();
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             mMobileAccessibilityHelper = new JellyBeanMobileAccessibilityHelper();

--- a/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
@@ -107,11 +107,6 @@ public class MobileAccessibility extends CordovaPlugin {
                 stop();
                 return true;
             } else if (action.equals("disableDisplayZoom")) {
-                /*cordova.getActivity().runOnUiThread(new Runnable() {
-                    public void run() {
-                        mMobileAccessibilityHelper.disableDisplayZoom();
-                    }
-                });*/
                 mMobileAccessibilityHelper.disableDisplayZoom();
                 return true;
             }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
@@ -106,8 +106,8 @@ public class MobileAccessibility extends CordovaPlugin {
             } else if (action.equals("stop")) {
                 stop();
                 return true;
-            } else if (action.equals("disableDisplayZoom")) {
-                mMobileAccessibilityHelper.disableDisplayZoom();
+            } else if (action.equals("setFontScaleToOne")) {
+                mMobileAccessibilityHelper.setFontScaleToOne();
                 return true;
             }
         } catch (JSONException e) {

--- a/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
@@ -107,11 +107,12 @@ public class MobileAccessibility extends CordovaPlugin {
                 stop();
                 return true;
             } else if (action.equals("disableDisplayZoom")) {
-                cordova.getActivity().runOnUiThread(new Runnable() {
+                /*cordova.getActivity().runOnUiThread(new Runnable() {
                     public void run() {
                         mMobileAccessibilityHelper.disableDisplayZoom();
                     }
-                });
+                });*/
+                mMobileAccessibilityHelper.disableDisplayZoom();
                 return true;
             }
         } catch (JSONException e) {

--- a/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
@@ -106,6 +106,13 @@ public class MobileAccessibility extends CordovaPlugin {
             } else if (action.equals("stop")) {
                 stop();
                 return true;
+            } else if (action.equals("disableDisplayZoom")) {
+                cordova.getActivity().runOnUiThread(new Runnable() {
+                    public void run() {
+                        mMobileAccessibilityHelper.disableDisplayZoom();
+                    }
+                });
+                return true;
             }
         } catch (JSONException e) {
             e.printStackTrace();

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -48,7 +48,7 @@ public class OreoMobileAccessibilityHelper extends
       metrics.scaledDensity = configuration.fontScale * metrics.density;
       configuration.densityDpi = (int) mContext.getResources().getDisplayMetrics().xdpi;
       mContext.getResources().updateConfiguration(configuration, metrics);
-      Toast.makeText(mContext, metrics.scaledDensity.toString() +  " | " + configuration.densityDpi.toString(), Toast.LENGTH_LONG).show();
+      Toast.makeText(mContext, String.valueOf(metrics.scaledDensity) +  " | " + String.valueOf(configuration.densityDpi), Toast.LENGTH_LONG).show();
     } catch (Exception e) {
       Toast.makeText(mContext, "disableDisplayZoom: " + e.toString(), Toast.LENGTH_SHORT).show();
     }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -47,7 +47,7 @@ public class OreoMobileAccessibilityHelper extends
       DisplayMetrics metrics = new DisplayMetrics();
       ((WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getMetrics(metrics);
       metrics.scaledDensity = configuration.fontScale * metrics.density;
-      configuration.densityDpi = (int) mContext.getResources().getDisplayMetrics().xdpi;
+      //configuration.densityDpi = (int) mContext.getResources().getDisplayMetrics().xdpi;
       mContext.getResources().updateConfiguration(configuration, metrics);
       Toast.makeText(mContext, String.valueOf(metrics.scaledDensity) +  " | " + String.valueOf(configuration.densityDpi), Toast.LENGTH_LONG).show();
     } catch (Exception e) {

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -50,7 +50,7 @@ public class OreoMobileAccessibilityHelper extends
       mContext.getResources().updateConfiguration(configuration, metrics);
       Toast.makeText(mContext, metrics.scaledDensity.toString() +  " | " + configuration.densityDpi.toString(), Toast.LENGTH_LONG).show();
     } catch (Exception e) {
-      Toast.makeText(mContext, "disableDisplayZoom: " e.toString(), Toast.LENGTH_SHORT).show();
+      Toast.makeText(mContext, "disableDisplayZoom: " + e.toString(), Toast.LENGTH_SHORT).show();
     }
   }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -1,0 +1,40 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+package com.phonegap.plugin.mobileaccessibility;
+
+import android.accessibilityservice.AccessibilityServiceInfo;
+import android.annotation.TargetApi;
+
+@TargetApi(26)
+public class OreoMobileAccessibilityHelper extends
+        KitKatMobileAccessibilityHelper {
+    @Override
+    public void disableDisplayZoom() {
+        Configuration configuration = getResources().getConfiguration();
+        configuration.fontScale = (float) 1; //0.85 small size, 1 normal size, 1,15 big etc
+        DisplayMetrics metrics = new DisplayMetrics();
+        getWindowManager().getDefaultDisplay().getMetrics(metrics);
+        metrics.scaledDensity = configuration.fontScale * metrics.density;
+        configuration.densityDpi = (int) getResources().getDisplayMetrics().xdpi;
+        getBaseContext().getResources().updateConfiguration(configuration, metrics);
+    }
+}

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -48,9 +48,9 @@ public class OreoMobileAccessibilityHelper extends
       metrics.scaledDensity = configuration.fontScale * metrics.density;
       configuration.densityDpi = (int) mContext.getResources().getDisplayMetrics().xdpi;
       mContext.getResources().updateConfiguration(configuration, metrics);
-      Toast.makeText(mContext, "Display zoom disabled.", Toast.LENGTH_SHORT).show();
+      Toast.makeText(mContext, metrics.scaledDensity.toString() +  " | " + configuration.densityDpi.toString(), Toast.LENGTH_LONG).show();
     } catch (Exception e) {
-      Toast.makeText(mContext, e.toString(), Toast.LENGTH_SHORT).show();
+      Toast.makeText(mContext, "disableDisplayZoom: " e.toString(), Toast.LENGTH_SHORT).show();
     }
   }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -44,7 +44,7 @@ public class OreoMobileAccessibilityHelper extends
       Configuration configuration = mContext.getResources().getConfiguration();
       configuration.fontScale = (float) 1; //0.85 small size, 1 normal size, 1,15 big etc
       DisplayMetrics metrics = new DisplayMetrics();
-      mContext.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+      ((WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getMetrics(metrics);
       metrics.scaledDensity = configuration.fontScale * metrics.density;
       configuration.densityDpi = (int) mContext.getResources().getDisplayMetrics().xdpi;
       mContext.getResources().updateConfiguration(configuration, metrics);

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -42,7 +42,7 @@ public class OreoMobileAccessibilityHelper extends
   public void disableDisplayZoom() {
     try {
       Configuration configuration = mContext.getResources().getConfiguration();
-      Toast.makeText(mContext, configuration.fontScale, Toast.LENGTH_LONG).show();
+      Toast.makeText(mContext, String.valueOf(configuration.fontScale), Toast.LENGTH_LONG).show();
       configuration.fontScale = (float) 1; //0.85 small size, 1 normal size, 1,15 big etc
       DisplayMetrics metrics = new DisplayMetrics();
       ((WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getMetrics(metrics);

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -38,20 +38,4 @@ public class OreoMobileAccessibilityHelper extends
     super.initialize(mobileAccessibility);
     mContext = mobileAccessibility.cordova.getActivity().getBaseContext();
   }
-  @Override
-  public void disableDisplayZoom() {
-    try {
-      Configuration configuration = mContext.getResources().getConfiguration();
-      //Toast.makeText(mContext, String.valueOf(configuration.fontScale), Toast.LENGTH_LONG).show();
-      configuration.fontScale = (float) 0.85; //0.85 small size, 1 normal size, 1,15 big etc
-      DisplayMetrics metrics = new DisplayMetrics();
-      ((WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getMetrics(metrics);
-      metrics.scaledDensity = configuration.fontScale * metrics.density;
-      //configuration.densityDpi = (int) mContext.getResources().getDisplayMetrics().xdpi;
-      mContext.getResources().updateConfiguration(configuration, metrics);
-      Toast.makeText(mContext, String.valueOf(metrics.scaledDensity) +  " | " + String.valueOf(configuration.densityDpi), Toast.LENGTH_LONG).show();
-    } catch (Exception e) {
-      Toast.makeText(mContext, "disableDisplayZoom: " + e.toString(), Toast.LENGTH_SHORT).show();
-    }
-  }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -42,13 +42,14 @@ public class OreoMobileAccessibilityHelper extends
   public void disableDisplayZoom() {
     try {
       Configuration configuration = mContext.getResources().getConfiguration();
+      Toast.makeText(mContext, configuration.fontScale, Toast.LENGTH_LONG).show();
       configuration.fontScale = (float) 1; //0.85 small size, 1 normal size, 1,15 big etc
       DisplayMetrics metrics = new DisplayMetrics();
       ((WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getMetrics(metrics);
       metrics.scaledDensity = configuration.fontScale * metrics.density;
       configuration.densityDpi = (int) mContext.getResources().getDisplayMetrics().xdpi;
       mContext.getResources().updateConfiguration(configuration, metrics);
-      Toast.makeText(mContext, String.valueOf(metrics.scaledDensity) +  " | " + String.valueOf(configuration.densityDpi), Toast.LENGTH_LONG).show();
+      //Toast.makeText(mContext, String.valueOf(metrics.scaledDensity) +  " | " + String.valueOf(configuration.densityDpi), Toast.LENGTH_LONG).show();
     } catch (Exception e) {
       Toast.makeText(mContext, "disableDisplayZoom: " + e.toString(), Toast.LENGTH_SHORT).show();
     }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -17,24 +17,35 @@
  * specific language governing permissions and limitations
  * under the License.
  *
-*/
+ */
 
 package com.phonegap.plugin.mobileaccessibility;
 
 import android.accessibilityservice.AccessibilityServiceInfo;
 import android.annotation.TargetApi;
+import android.widget.Toast;
+import android.content.res.Configuration;
+import android.view.WindowManager;
+import android.util.DisplayMetrics;
+import android.content.Context;
 
 @TargetApi(26)
 public class OreoMobileAccessibilityHelper extends
-        KitKatMobileAccessibilityHelper {
-    @Override
-    public void disableDisplayZoom() {
-        Configuration configuration = getResources().getConfiguration();
-        configuration.fontScale = (float) 1; //0.85 small size, 1 normal size, 1,15 big etc
-        DisplayMetrics metrics = new DisplayMetrics();
-        getWindowManager().getDefaultDisplay().getMetrics(metrics);
-        metrics.scaledDensity = configuration.fontScale * metrics.density;
-        configuration.densityDpi = (int) getResources().getDisplayMetrics().xdpi;
-        getBaseContext().getResources().updateConfiguration(configuration, metrics);
+    KitKatMobileAccessibilityHelper {
+  @Override
+  public void disableDisplayZoom() {
+    try {
+      Context context = this.cordova.getActivity().getBaseContext();
+      Configuration configuration = context.getResources().getConfiguration();
+      configuration.fontScale = (float) 1; //0.85 small size, 1 normal size, 1,15 big etc
+      DisplayMetrics metrics = new DisplayMetrics();
+      context.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+      metrics.scaledDensity = configuration.fontScale * metrics.density;
+      configuration.densityDpi = (int) context.getResources().getDisplayMetrics().xdpi;
+      context.getResources().updateConfiguration(configuration, metrics);
+      Toast.makeText(context, "Display zoom disabled.", Toast.LENGTH_SHORT).show();
+    } catch (Exception e) {
+      Toast.makeText(context, e.toString(), Toast.LENGTH_SHORT).show();
     }
+  }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -32,20 +32,25 @@ import android.content.Context;
 @TargetApi(26)
 public class OreoMobileAccessibilityHelper extends
     KitKatMobileAccessibilityHelper {
+  private Context mContext;
+  @Override
+  public void initialize(MobileAccessibility mobileAccessibility) {
+    super.initialize(mobileAccessibility);
+    mContext = mobileAccessibility.cordova.getActivity().getBaseContext();
+  }
   @Override
   public void disableDisplayZoom() {
     try {
-      Context context = this.cordova.getActivity().getBaseContext();
-      Configuration configuration = context.getResources().getConfiguration();
+      Configuration configuration = mContext.getResources().getConfiguration();
       configuration.fontScale = (float) 1; //0.85 small size, 1 normal size, 1,15 big etc
       DisplayMetrics metrics = new DisplayMetrics();
-      context.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+      mContext.getWindowManager().getDefaultDisplay().getMetrics(metrics);
       metrics.scaledDensity = configuration.fontScale * metrics.density;
-      configuration.densityDpi = (int) context.getResources().getDisplayMetrics().xdpi;
-      context.getResources().updateConfiguration(configuration, metrics);
-      Toast.makeText(context, "Display zoom disabled.", Toast.LENGTH_SHORT).show();
+      configuration.densityDpi = (int) mContext.getResources().getDisplayMetrics().xdpi;
+      mContext.getResources().updateConfiguration(configuration, metrics);
+      Toast.makeText(mContext, "Display zoom disabled.", Toast.LENGTH_SHORT).show();
     } catch (Exception e) {
-      Toast.makeText(context, e.toString(), Toast.LENGTH_SHORT).show();
+      Toast.makeText(mContext, e.toString(), Toast.LENGTH_SHORT).show();
     }
   }
 }

--- a/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/OreoMobileAccessibilityHelper.java
@@ -42,14 +42,14 @@ public class OreoMobileAccessibilityHelper extends
   public void disableDisplayZoom() {
     try {
       Configuration configuration = mContext.getResources().getConfiguration();
-      Toast.makeText(mContext, String.valueOf(configuration.fontScale), Toast.LENGTH_LONG).show();
-      configuration.fontScale = (float) 1; //0.85 small size, 1 normal size, 1,15 big etc
+      //Toast.makeText(mContext, String.valueOf(configuration.fontScale), Toast.LENGTH_LONG).show();
+      configuration.fontScale = (float) 0.85; //0.85 small size, 1 normal size, 1,15 big etc
       DisplayMetrics metrics = new DisplayMetrics();
       ((WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getMetrics(metrics);
       metrics.scaledDensity = configuration.fontScale * metrics.density;
       configuration.densityDpi = (int) mContext.getResources().getDisplayMetrics().xdpi;
       mContext.getResources().updateConfiguration(configuration, metrics);
-      //Toast.makeText(mContext, String.valueOf(metrics.scaledDensity) +  " | " + String.valueOf(configuration.densityDpi), Toast.LENGTH_LONG).show();
+      Toast.makeText(mContext, String.valueOf(metrics.scaledDensity) +  " | " + String.valueOf(configuration.densityDpi), Toast.LENGTH_LONG).show();
     } catch (Exception e) {
       Toast.makeText(mContext, "disableDisplayZoom: " + e.toString(), Toast.LENGTH_SHORT).show();
     }

--- a/www/mobile-accessibility.js
+++ b/www/mobile-accessibility.js
@@ -315,6 +315,10 @@ MobileAccessibility.prototype.getTextZoom = function(callback) {
     exec(callback, null, "MobileAccessibility", "getTextZoom", []);
 };
 
+MobileAccessibility.prototype.disableDisplaySize = function(callback) {
+    exec(callback, null, "MobileAccessibility", "disableDisplaySize", []);
+};
+
 /**
  * Asynchronous call to native MobileAccessibility to set the current text zoom percent value for the WebView.
  * @param {Number} textZoom A percentage value by which text in the WebView should be scaled.
@@ -339,7 +343,7 @@ MobileAccessibility.prototype.usePreferredTextZoom = function(bool) {
         return currentValue;
     }
 
-    if (currentValue != bool) {
+    if (currentValue !== bool) {
         window.localStorage.setItem("MobileAccessibility.usePreferredTextZoom", bool);
     }
 
@@ -388,7 +392,7 @@ MobileAccessibility.prototype.speak = function(string, queueMode, properties) {
     } else {
         exec(null, null, "MobileAccessibility", "postNotification", [MobileAccessibilityNotifications.ANNOUNCEMENT, string]);
     }
-}
+};
 
 /**
  * Stops speech.
@@ -399,7 +403,7 @@ MobileAccessibility.prototype.stop = function() {
     } else {
         exec(null, null, "MobileAccessibility", "postNotification", [MobileAccessibilityNotifications.ANNOUNCEMENT, "\u200b"]);
     }
-}
+};
 
 /**
  * Callback from native MobileAccessibility returning an object which describes the status of MobileAccessibility features.

--- a/www/mobile-accessibility.js
+++ b/www/mobile-accessibility.js
@@ -315,8 +315,8 @@ MobileAccessibility.prototype.getTextZoom = function(callback) {
     exec(callback, null, "MobileAccessibility", "getTextZoom", []);
 };
 
-MobileAccessibility.prototype.disableDisplayZoom = function(callback) {
-    exec(callback, null, "MobileAccessibility", "disableDisplayZoom", []);
+MobileAccessibility.prototype.setFontScaleToOne = function(callback) {
+    exec(callback, null, "MobileAccessibility", "setFontScaleToOne", []);
 };
 
 /**
@@ -363,6 +363,7 @@ MobileAccessibility.prototype.usePreferredTextZoom = function(bool) {
         mobileAccessibility.updateTextZoom();
     } else {
         mobileAccessibility.setTextZoom(100);
+        mobileAccessibility.setFontScaleToOne();
     }
 
     return Boolean(bool);

--- a/www/mobile-accessibility.js
+++ b/www/mobile-accessibility.js
@@ -315,8 +315,8 @@ MobileAccessibility.prototype.getTextZoom = function(callback) {
     exec(callback, null, "MobileAccessibility", "getTextZoom", []);
 };
 
-MobileAccessibility.prototype.disableDisplaySize = function(callback) {
-    exec(callback, null, "MobileAccessibility", "disableDisplaySize", []);
+MobileAccessibility.prototype.disableDisplayZoom = function(callback) {
+    exec(callback, null, "MobileAccessibility", "disableDisplayZoom", []);
 };
 
 /**


### PR DESCRIPTION

### Summary of Changes
#### README.md
- Added `MobileAccessibility.disableDisplayZoom` to the list of available methods.
- Provided documentation for the new `disableDisplayZoom` method.

#### package.json
- Updated the homepage and bugs URLs to point to the new repository `newage99/phonegap-plugin-mobile-accessibility`.
- Bumped the version from `1.0.5` to `1.0.9`.

#### plugin.xml
- Added a new source file `OreoMobileAccessibilityHelper.java` for Android.
- Updated the plugin version to `1.0.9`.

#### AbstractMobileAccessibilityHelper.java
- Added a new abstract method `setFontScaleToOne`.

#### DonutMobileAccessibilityHelper.java
- Implemented the `setFontScaleToOne` method to set the font scale to 1.

#### MobileAccessibility.java
- Initialized `OreoMobileAccessibilityHelper` for devices with Android O (API level 26) or higher.
- Added support for the `setFontScaleToOne` action.

#### OreoMobileAccessibilityHelper.java
- Created a new helper class extending `KitKatMobileAccessibilityHelper`.

#### mobile-accessibility.js
- Added a new JavaScript method `setFontScaleToOne`.
- Updated the `usePreferredTextZoom` method to call `setFontScaleToOne`.

### Impact
These changes introduce new functionality for handling font scaling and disabling display zoom settings. They also update documentation and references to reflect these additions.